### PR TITLE
Add Xcompact3d code definition

### DIFF
--- a/app-data/code-definitions/xcompact3d.code
+++ b/app-data/code-definitions/xcompact3d.code
@@ -23,8 +23,8 @@ name: Xcompact3d
 regexp: xcompact3d
 
 [metadata]
-primary language: Fortran90
-version:          
+primary language: Fortran
+version:          90
 
 academic license: Open Source
 commercial license: Open Source

--- a/app-data/code-definitions/xcompact3d.code
+++ b/app-data/code-definitions/xcompact3d.code
@@ -1,0 +1,35 @@
+#----------------------------------------------------------------------
+# Copyright 2021 EPCC, The University of Edinburgh
+#
+# This file is part of usage-analysis.
+#
+# usage-analysis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# usage-analysis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with usage-analysis.  If not, see <http://www.gnu.org/licenses/>.
+#----------------------------------------------------------------------
+#
+
+[code info]
+name: Xcompact3d
+regexp: xcompact3d
+
+[metadata]
+primary language: Fortran90
+version:          
+
+academic license: Open Source
+commercial license: Open Source
+
+code type: Structured Grid
+
+research area: Computational Fluid Dynamics
+parallel-model: MPI


### PR DESCRIPTION
The Xcompact3d code is one of the primary codes of the UK Turbulence
Consortium.