### PR TITLE
Update executable names for Nektar++

### DIFF
--- a/app-data/code-definitions/nektar.code
+++ b/app-data/code-definitions/nektar.code
@@ -20,7 +20,7 @@
 
 [code info]
 name: Nektar++
-regexp: IncNavierStok
+regexp: IncNavierStok|CompressibleFlowSolver|APESolver|AcousticSolver
 
 [metadata]
 primary language: C++


### PR DESCRIPTION
In addition to IncNavierStokesSolver, also look for
- CompressibleFlowSolver
- APESolver
- AcousticSolver

After making this change Nektar++ usage goes from 0.4% to 0.7% in the Feb22 period